### PR TITLE
Rebuild for older ldas-tools-{al,framecpp}

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 4ef5f52a68016abb252df2afb7bba57300eb3ccd795975d07e5ffb5a723b9fca
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 outputs:
@@ -37,8 +37,8 @@ outputs:
         - gds-base >={{ gds_base_version }}
         - gds-base-gdstrig >={{ gds_base_version }}
         - gds-lsmp >={{ gds_lsmp_version }}
-        - ldas-tools-al
-        - ldas-tools-framecpp >={{ ldas_tools_framecpp_version }}
+        - ldas-tools-al 2.6.4
+        - ldas-tools-framecpp 2.7.0
       run:
         - gds-base >={{ gds_base_version }}
         - gds-lsmp >={{ gds_lsmp_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,15 +45,7 @@ outputs:
         - ldas-tools-al
         - ldas-tools-framecpp >={{ ldas_tools_framecpp_version }}
     test:
-      requires:
-        - pkg-config
-      commands:
-        - pkg-config --print-errors --exact-version {{ version }} gdsframeio
-        - fdir -h
-        - fextract -h
-        - finfo -h
-        - framedump -h  # [not osx]
-        - fsettime -h
+      script: test-gds-frameio-base.sh
     about:
       home: https://wiki.ligo.org/Computing/DASWG/DMT
       dev_url: https://git.ligo.org/gds/gds.git

--- a/recipe/test-gds-frameio-base.sh
+++ b/recipe/test-gds-frameio-base.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# IGWN Conda Distribution tests for gds-frameio-base
+#
+
+set -ex
+
+# use framecpp_sample to generate some fake data
+framecpp_sample --description IGWN_CONDA_TEST --start-time 1000000000
+GWF="Z-IGWN_CONDA_TEST-1000000000-1.gwf"
+
+# print frame segments
+fdir ${GWF}
+
+# print frame info
+finfo ${GWF}
+
+# dump ascii
+fextract Z0:RAMPED_INT_2U_1 ${GWF} data.txt
+
+# dump frame
+framedump ${GWF}
+
+# set time
+fsettime .

--- a/recipe/test-gds-frameio-base.sh
+++ b/recipe/test-gds-frameio-base.sh
@@ -18,8 +18,11 @@ finfo ${GWF}
 # dump ascii
 fextract Z0:RAMPED_INT_2U_1 ${GWF} data.txt
 
-# dump frame
-framedump ${GWF}
+# dump frame (only on Linux)
+FrameDump -i ${GWF}
+if [ "$(uname)" = "Linux" ]; then
+	framedump ${GWF}
+fi
 
 # set time
 fsettime .


### PR DESCRIPTION
This PR rebuilds gds-frameio-base against slightly older versions of `ldas-tools-al` and `ldas-tools-framecpp` to maximise compatibility with other packages.

I also added proper tests.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
